### PR TITLE
Improved ScreenTime remover

### DIFF
--- a/Cowabunga/Controllers/Background/BackgroundFileUpdaterController.swift
+++ b/Cowabunga/Controllers/Background/BackgroundFileUpdaterController.swift
@@ -93,6 +93,9 @@ class BackgroundFileUpdaterController: ObservableObject {
             
             // apply to audios
             let _ = AudioFiles.applyAllAudio()
+            
+            // kill screentime agent
+            killSTA()
         }
     }
 }

--- a/Cowabunga/Controllers/Background/BackgroundFileUpdaterController.swift
+++ b/Cowabunga/Controllers/Background/BackgroundFileUpdaterController.swift
@@ -95,7 +95,9 @@ class BackgroundFileUpdaterController: ObservableObject {
             let _ = AudioFiles.applyAllAudio()
             
             // kill screentime agent
-            killSTA()
+            if UserDefaults.standard.bool(forKey: "stakillerenabled") == true {
+                killSTA()
+            }
         }
     }
 }

--- a/Cowabunga/Controllers/MiscModsManager.swift
+++ b/Cowabunga/Controllers/MiscModsManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import MacDirtyCowSwift
+import SystemConfiguration
 
 enum SettingsOptionType: String {
     case textbox = "PSEditTextCell"
@@ -58,7 +59,14 @@ func modifyScreenTime(enabled: Bool) throws {
             let data = try Data(contentsOf: URL(fileURLWithPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"))
             try data.write(to: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
             try FileManager.default.removeItem(at: URL(fileURLWithPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"))
-        } else {
+            killSTA()
+        }
+        // Check if there is a TrollBox backup
+        else if FileManager.default.fileExists(atPath: "/var/mobile/Library/Preferences/live.cclerc.ScreenTimeAgent.plist") && !FileManager.default.fileExists(atPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"){
+            let data = try Data(contentsOf: URL(fileURLWithPath: "/var/mobile/Library/Preferences/live.cclerc.ScreenTimeAgent.plist"))
+            try data.write(to: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
+        }
+        else {
             throw "No screentime file backup found!"
         }
     } else {
@@ -66,8 +74,43 @@ func modifyScreenTime(enabled: Bool) throws {
         let data = try Data(contentsOf: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
         try data.write(to: URL(fileURLWithPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"))
         try FileManager.default.removeItem(at: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
+        killSTA()
     }
 }
+
+// Screentime related
+func killSTA() {
+    // Kill the ScreenTime process - This is based of different sources, wich indicate to kill some of these process
+    xpc_crash("com.apple.ScreenTimeAgent")
+    xpc_crash("com.apple.ScreenTimeAgent.plist")
+    xpc_crash("com.apple.ScreenTime")
+    xpc_crash("com.apple.ScreenTimeAgent")
+    xpc_crash("ScreenTimeAgent")
+}
+func isInternetAvailable() -> Bool {
+    // This will check if internet is enabled, if yes, return true
+    var zeroAddress = sockaddr_in()
+    zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))
+    zeroAddress.sin_family = sa_family_t(AF_INET)
+    
+    guard let reachability = withUnsafePointer(to: &zeroAddress, {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            SCNetworkReachabilityCreateWithAddress(nil, $0)
+        }
+    }) else {
+        return false
+    }
+    
+    var flags = SCNetworkReachabilityFlags()
+    if !SCNetworkReachabilityGetFlags(reachability, &flags) {
+        return false
+    }
+    
+    let isReachable = (flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0
+    let needsConnection = (flags.rawValue & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
+    return (isReachable && !needsConnection)
+}
+
 
 func setValueInSystemVersionPlist(key: String, value: String) throws -> String {
     let filePath: String = "/System/Library/CoreServices/SystemVersion.plist"

--- a/Cowabunga/Controllers/MiscModsManager.swift
+++ b/Cowabunga/Controllers/MiscModsManager.swift
@@ -60,11 +60,14 @@ func modifyScreenTime(enabled: Bool) throws {
             try data.write(to: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
             try FileManager.default.removeItem(at: URL(fileURLWithPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"))
             killSTA()
+            UserDefaults.standard.set(false, forKey: "stakillerenabled")
         }
         // Check if there is a TrollBox backup
         else if FileManager.default.fileExists(atPath: "/var/mobile/Library/Preferences/live.cclerc.ScreenTimeAgent.plist") && !FileManager.default.fileExists(atPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"){
             let data = try Data(contentsOf: URL(fileURLWithPath: "/var/mobile/Library/Preferences/live.cclerc.ScreenTimeAgent.plist"))
             try data.write(to: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
+            killSTA()
+            UserDefaults.standard.set(false, forKey: "stakillerenabled")
         }
         else {
             throw "No screentime file backup found!"
@@ -75,6 +78,7 @@ func modifyScreenTime(enabled: Bool) throws {
         try data.write(to: URL(fileURLWithPath: "/var/mobile/Library/Preferences/.BACKUP_com.apple.ScreenTimeAgent.plist"))
         try FileManager.default.removeItem(at: URL(fileURLWithPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist"))
         killSTA()
+        UserDefaults.standard.set(true, forKey: "stakillerenabled")
     }
 }
 

--- a/Cowabunga/Views/NavigatorViews/HomeView.swift
+++ b/Cowabunga/Views/NavigatorViews/HomeView.swift
@@ -277,7 +277,7 @@ struct HomeView: View {
                     // app credits
                     LinkCell(imageName: "leminlimez", url: "https://github.com/leminlimez", title: "leminlimez", contribution: NSLocalizedString("Main Developer", comment: "leminlimez's contribution"), circle: true)
                     LinkCell(imageName: "sourcelocation", url: "https://github.com/sourcelocation", title: "sourcelocation", contribution: NSLocalizedString("Main Developer", comment: "sourcelocation's contribution"), circle: true)
-                    LinkCell(imageName: "c22dev", url: "https://github.com/c22dev", title: "c22dev", contribution: NSLocalizedString("Included Audio, Credits, and Card Changer", comment: "c22dev's contribution"), circle: true)
+                    LinkCell(imageName: "c22dev", url: "https://github.com/c22dev", title: "c22dev", contribution: NSLocalizedString("ScreenTime Remover, Included Audio, Credits, and Card Changer", comment: "c22dev's contribution"), circle: true)
                     LinkCell(imageName: "zhuowei", url: "https://twitter.com/zhuowei/", title: "zhuowei", contribution: NSLocalizedString("Unsandboxing", comment: "zhuowei's contribution"), circle: true)
                     LinkCell(imageName: "haxi0", url: "https://github.com/haxi0", title: "haxi0", contribution: "TrollLock", circle: true)
                     LinkCell(imageName: "ginsudev", url: "https://github.com/ginsudev/WDBFontOverwrite", title: "ginsudev", contribution: NSLocalizedString("Exploit Code", comment: "ginsudev's contribution"), circle: true)

--- a/Cowabunga/Views/NavigatorViews/OtherModsView.swift
+++ b/Cowabunga/Views/NavigatorViews/OtherModsView.swift
@@ -20,6 +20,7 @@ struct OtherModsView: View {
     @State private var supervised: Bool = UserDefaults.standard.bool(forKey: "IsSupervised")
     
     @State private var screenTimeEnabled: Bool = FileManager.default.fileExists(atPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist")
+    @State private var internet_showed_once = false
     
     struct DeviceSubType: Identifiable {
         var id = UUID()
@@ -193,8 +194,16 @@ struct OtherModsView: View {
                     }.onChange(of: screenTimeEnabled) { new in
                         // set the value
                         do {
-                            try modifyScreenTime(enabled: screenTimeEnabled)
-                            UIApplication.shared.alert(title: NSLocalizedString("Success!", comment: ""), body: NSLocalizedString("Screen time was successfully disabled, please reboot to finish application.", comment: ""))
+                            let webconnected = isInternetAvailable()
+                            if webconnected == true && internet_showed_once == false {
+                                UIApplication.shared.alert(title: NSLocalizedString("Your device is connected to internet!", comment: ""), body: NSLocalizedString("This could cause issues. Make sure to disable data or Wi-Fi.", comment: "screentime process"))
+                            screenTimeEnabled = FileManager.default.fileExists(atPath: "/var/mobile/Library/Preferences/com.apple.ScreenTimeAgent.plist")
+                            internet_showed_once = true
+                            }
+                            else {
+                                try modifyScreenTime(enabled: screenTimeEnabled)
+                                UIApplication.shared.alert(title: NSLocalizedString("Success!", comment: ""), body: NSLocalizedString("Screen time was successfully disabled, please reboot to finish application. You will be able to enable connection after restart.", comment: ""))
+                            }
                         } catch {
                             UIApplication.shared.alert(body: error.localizedDescription)
                         }


### PR DESCRIPTION
Hello there, here are the changes I've made : 

- **iCloud ScreenTime support**
    - By killing _ScreenTimeAgent_, this stop the fetch of the plist wich is made by the daemon in background
    - The daemon is killed in _background_, because iOS can respawns the agent at any time
- **Support for _TrollBox_ saves**
- **Better warning pop-ups**
