### PR TITLE
Fix Issue #300 for iOS 16.2 Beta 1 users.

### DIFF
--- a/Cowabunga/App/CowabungaApp.swift
+++ b/Cowabunga/App/CowabungaApp.swift
@@ -34,7 +34,8 @@ struct CowabungaApp: App {
                     
 #if targetEnvironment(simulator)
 #else
-                    if #available(iOS 16.2, *) {
+                    // fix Issue #300 | If ForceMDC is enabled it will override 16.2 unsupported limitation, for Beta users.
+                    if #available(iOS 16.2, *), UserDefaults.standard.bool(forKey: "ForceMDC") == false {
                         UIApplication.shared.alert(title: "Not Supported", body: "This version of iOS is not supported.")
                     } else {
                         do {


### PR DESCRIPTION
## Now If `ForceMDC` is applied, the iOS 16.2 check gets skipped/has dual conditions as mentioned by @core-hacked in #300